### PR TITLE
[FE] Fix: signin response 변경

### DIFF
--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -17,6 +17,11 @@ type SignInPropsType = {
   autoLogin: boolean
 }
 
+type SignInResType = {
+  status: 'success' | 'fail'
+  memberId: number | null
+}
+
 export type UserInfoType = {
   defaultWalkLogPublicSetting: string
   email: string
@@ -43,15 +48,19 @@ export const signUp = async ({ nickname, email, password }: SignUpPropsType) => 
   }
 }
 
-export const signIn = async ({ email, password, autoLogin = true }: SignInPropsType) => {
+export const signIn = async ({
+  email,
+  password,
+  autoLogin = true,
+}: SignInPropsType): Promise<SignInResType> => {
   try {
     const response = await axios.post('/api/members/login', { email, password, autoLogin })
     const { authorization } = response.headers
     axios.defaults.headers.common.Authorization = authorization
     saveRefreshTokenToLocalStorage(response.headers.refresh)
-    return response.data.memberId
+    return { status: 'success', memberId: response.data.memberId }
   } catch (error) {
-    return null
+    return { status: 'fail', memberId: null }
   }
 }
 

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -19,7 +19,7 @@ function SignIn() {
     const email = formData.get('email')
     const password = formData.get('password')
 
-    const memberId = await signIn({ email, password, autoLogin: true })
+    const { memberId } = await signIn({ email, password, autoLogin: true })
     setId(memberId)
 
     if (memberId) {


### PR DESCRIPTION
API 요청에 대한 응답을 기존 `memberId`, `'fail'`에서 객체 형태로 변경

```
{
  status: 'fail' | 'success'
  memberId: number | null
}
```