### PR TITLE
[FE] Fix: 한달 내 기록 다시 확인할 때 달력 재렌더링 막기 (#294)

### DIFF
--- a/client/src/pages/HistoryList.tsx
+++ b/client/src/pages/HistoryList.tsx
@@ -9,7 +9,6 @@ import { getHistoryList } from '../apis/history'
 import { userAtom } from '../store/authAtom'
 import { HistoryListDataType } from '../types/History'
 import { getDate, getMonth, getYear } from '../utils/date-fns'
-import HistoryListLoading from './loadingPage/HistoryListLoading'
 import HistoryLoading from './loadingPage/HistoryLoading'
 
 export default function HistoryList() {
@@ -22,29 +21,28 @@ export default function HistoryList() {
     setCalendar(!calendar)
   }
 
-  const { isLoading, isError, data, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useInfiniteQuery({
-      queryKey: ['history', calendar, date, selectDate],
-      queryFn: ({ pageParam }) => {
-        if (calendar && selectDate) {
-          return getHistoryList(
-            user.memberId,
-            pageParam,
-            getYear(selectDate),
-            getMonth(selectDate) + 1,
-            getDate(selectDate)
-          )
-        }
-        if (calendar) {
-          return getHistoryList(user.memberId, pageParam, getYear(date), getMonth(date) + 1)
-        }
-        return getHistoryList(user.memberId, pageParam)
-      },
-      getNextPageParam: lastPage => {
-        const { page, totalPages } = lastPage.pageInfo
-        return page < totalPages ? page + 1 : undefined
-      },
-    })
+  const { isError, data, isFetchingNextPage, hasNextPage, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['history', calendar, date, selectDate],
+    queryFn: ({ pageParam }) => {
+      if (calendar && selectDate) {
+        return getHistoryList(
+          user.memberId,
+          pageParam,
+          getYear(selectDate),
+          getMonth(selectDate) + 1,
+          getDate(selectDate)
+        )
+      }
+      if (calendar) {
+        return getHistoryList(user.memberId, pageParam, getYear(date), getMonth(date) + 1)
+      }
+      return getHistoryList(user.memberId, pageParam)
+    },
+    getNextPageParam: lastPage => {
+      const { page, totalPages } = lastPage.pageInfo
+      return page < totalPages ? page + 1 : undefined
+    },
+  })
 
   const intObserver = useRef<IntersectionObserver>()
   const lastHistoryRef = useCallback(
@@ -65,7 +63,6 @@ export default function HistoryList() {
     [isFetchingNextPage, fetchNextPage, hasNextPage]
   )
 
-  if (isLoading) return <HistoryListLoading />
   if (isError) return <h1>Fail...</h1>
 
   const body = data?.pages.map(page => {


### PR DESCRIPTION
날짜의 api 요청하고 받아오는 동안 전체화면이 로딩 화면으로 보였다가 다시 돌아와서 생긴 문제여서, is loading 일때 보이던 컴포넌츠 삭제