### PR TITLE
[FE] Feat: 입력된 공백, 띄어쓰기 살려서 보여주기

### DIFF
--- a/client/src/components/HistoryDetail/DetailItem.tsx
+++ b/client/src/components/HistoryDetail/DetailItem.tsx
@@ -73,7 +73,7 @@ export default function DetailItem({
         </div>
       )}
       {imageUrl && imgModal && <ImgModal imageUrl={imageUrl} onClose={handlePhotoModal} />}
-      <div className={styles.textBox}>
+      <pre className={styles.textBox}>
         {text}
         <div className={styles.iconsBox}>
           <div className={styles.icon}>
@@ -92,7 +92,7 @@ export default function DetailItem({
             </div>
           )}
         </div>
-      </div>
+      </pre>
     </article>
   )
 }

--- a/client/src/pages/HistoryList.module.scss
+++ b/client/src/pages/HistoryList.module.scss
@@ -4,7 +4,7 @@
 .container {
   width: 100%;
   @include U.flex-c(column);
-  padding-top: 64px;
+  // padding-top: 64px;
   padding-bottom: calc(constant(safe-area-inset-bottom) + 120px);
   padding-bottom: calc(env(safe-area-inset-bottom) + 120px);
 }

--- a/client/src/pages/HistoryList.module.scss
+++ b/client/src/pages/HistoryList.module.scss
@@ -4,7 +4,6 @@
 .container {
   width: 100%;
   @include U.flex-c(column);
-  // padding-top: 64px;
   padding-bottom: calc(constant(safe-area-inset-bottom) + 120px);
   padding-bottom: calc(env(safe-area-inset-bottom) + 120px);
 }


### PR DESCRIPTION
text 를 보여주는 태그를 `<pre>`로 바꿈
기록리스트의 토글 - 헤더 사이에 생긴 알 수 없는 간격 삭제