### PR TITLE
[FE] Design: 순간 기록에 이미지 없어도 텍스트 안삐져나오게 css 통일 

### DIFF
--- a/client/src/components/Feed/SnapItem.module.scss
+++ b/client/src/components/Feed/SnapItem.module.scss
@@ -27,12 +27,6 @@
   width: calc(100% - 96px);
 }
 
-.noImg {
-  @include U.flex-c(column, flex-start, start);
-  gap: 4px;
-  width: 100%;
-}
-
 .text {
   @include T.gray900-regular-12;
   width: 100%;

--- a/client/src/components/Feed/SnapItem.tsx
+++ b/client/src/components/Feed/SnapItem.tsx
@@ -15,7 +15,7 @@ export default function SnapItem({ item }: SnapItemProps) {
       <div className={styles.imgWrapper}>
         {imageUrl ? <img src={imageUrl} alt='올린 사진' /> : <Icon name='no-image' size={24} />}
       </div>
-      <div className={imageUrl ? styles.timeTextBox : styles.noImg}>
+      <div className={styles.timeTextBox}>
         <div className={styles.snapTimeBox}>
           <Icon name='time-gray' size={16} />
           <p> {format(new Date(createdAt), 'a h시 m분', { locale: ko })}</p>

--- a/client/src/components/HistoryList/HistoryItem.module.scss
+++ b/client/src/components/HistoryList/HistoryItem.module.scss
@@ -26,12 +26,6 @@
   width: calc(100% - 96px);
 }
 
-.noImg {
-  @include U.flex-c(column, flex-start, start);
-  gap: 4px;
-  width: 100%;
-}
-
 .text {
   @include T.gray600-regular-12;
   width: 100%;

--- a/client/src/components/HistoryList/HistoryItem.tsx
+++ b/client/src/components/HistoryList/HistoryItem.tsx
@@ -15,7 +15,7 @@ export default function HistoryItem({ item }: HistoryItemProps) {
       <div className={styles.imgWrapper}>
         {imageUrl ? <img src={imageUrl} alt='올린 사진' /> : <Icon name='no-image' size={24} />}
       </div>
-      <div className={imageUrl ? styles.timeTextBox : styles.noImg}>
+      <div className={styles.timeTextBox}>
         <div className={styles.snapTimeBox}>
           <Icon name='time-gray' size={16} />
           <p>{format(new Date(createdAt), 'a h시 m분', { locale: ko })}</p>


### PR DESCRIPTION
이미지 없는 경우 text 감싸는 상위 div 에 다른 스타일 적용되어 있던 것 삭제