### PR TITLE
[BE] 이미지 썸네일 저장 기능 구현

### DIFF
--- a/server/src/main/java/backend/section6mainproject/content/mapper/WalkLogContentMapper.java
+++ b/server/src/main/java/backend/section6mainproject/content/mapper/WalkLogContentMapper.java
@@ -4,6 +4,7 @@ import backend.section6mainproject.content.dto.WalkLogContentControllerDTO;
 import backend.section6mainproject.content.dto.WalkLogContentServiceDTO;
 import backend.section6mainproject.content.entity.WalkLogContent;
 import backend.section6mainproject.helper.image.StorageService;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -30,21 +31,24 @@ public interface WalkLogContentMapper {
     WalkLogContentControllerDTO.PostResponse serviceCreateOutputDTOToControllerCreateResponseDTO(WalkLogContentServiceDTO.CreateOutput createOutput);
 
     // response flow - for general
-    @Mapping(source = "imageKey", target = "imageUrl", qualifiedByName = "signBucket")
+    @Mapping(source = "imageKey", target = "imageUrl", qualifiedByName = "PreSignedUrl")
+    @Named("walkLogContentForOrigin")
     WalkLogContentServiceDTO.Output entityToServiceOutputDTO(WalkLogContent walkLogContent);
+
+    @Mapping(source = "imageKey", target = "imageUrl", qualifiedByName = "PreSignedUrlForThumbnail")
+    @Named("walkLogContentForThumbnail")
+    WalkLogContentServiceDTO.Output entityToServiceOutputDTOForThumbnail(WalkLogContent walkLogContent);
 
     WalkLogContentControllerDTO.Response serviceOutputDTOToControllerResponseDTO(WalkLogContentServiceDTO.Output output);
 
     @Named("walkLogContentEntityToServiceDTO")
+    @IterableMapping(qualifiedByName = "walkLogContentForOrigin")
     List<WalkLogContentServiceDTO.Output> entitiesToServiceOutputDTOs(List<WalkLogContent> walkLogContents);
+    @Named("walkLogContentEntityToServiceDTOForThumbnail")
+    @IterableMapping(qualifiedByName = "walkLogContentForThumbnail")
+    List<WalkLogContentServiceDTO.Output> entitiesToServiceOutputDTOsForThumbnail(List<WalkLogContent> walkLogContents);
     @Named("walkLogContentServiceDTOToControllerDTO")
     List<WalkLogContentControllerDTO.Response> serviceOutputDTOsToControllerResponseDTOs(List<WalkLogContentServiceDTO.Output> outputs);
 
 
-    // legacy codes
-
-    @Mapping(source = "imageKey", target = "imageUrl", qualifiedByName = "signBucket")
-    WalkLogContentControllerDTO.Response walkLogContentToWalkLogContentResponseDTO(WalkLogContent walkLogContent);
-    @Named("walkLogContentsToWalkLogContentResponseDTOs")
-    List<WalkLogContentControllerDTO.Response> walkLogContentsToWalkLogContentResponseDTOs(List<WalkLogContent> walkLogContents);
 }

--- a/server/src/main/java/backend/section6mainproject/content/service/WalkLogContentServiceImpl.java
+++ b/server/src/main/java/backend/section6mainproject/content/service/WalkLogContentServiceImpl.java
@@ -30,7 +30,7 @@ public class WalkLogContentServiceImpl implements WalkLogContentService {
 
         WalkLogContent walkLogContent = mapper.serviceCreateInputDTOToEntity(createInput);
         walkLogService.findVerifiedWalkLog(walkLogContent.getWalkLog().getWalkLogId());
-        String imageKey = storageService.store(createInput.getContentImage(), "content");
+        String imageKey = storageService.store(createInput.getContentImage(), "content", false);
         walkLogContent.setImageKey(imageKey);
         WalkLogContent savedWalkLogContent = walkLogContentRepository.save(walkLogContent);
         return mapper.entityToServiceCreateOutputDTO(savedWalkLogContent);
@@ -46,7 +46,7 @@ public class WalkLogContentServiceImpl implements WalkLogContentService {
     public WalkLogContentServiceDTO.Output updateWalkLogContent(WalkLogContentServiceDTO.UpdateInput updateInput) {
         WalkLogContent findWalkLogContent = findVerifiedWalkLogContentInternal(updateInput.getWalkLogContentId());
         Optional.ofNullable(updateInput.getText()).ifPresent(text -> findWalkLogContent.setText(text));
-        String imageKey = storageService.store(updateInput.getContentImage(), "content");
+        String imageKey = storageService.store(updateInput.getContentImage(), "content", false);
         if(imageKey != null || storageService.isEmptyFile(updateInput.getContentImage())) {
             storageService.delete(findWalkLogContent.getImageKey());
             findWalkLogContent.setImageKey(imageKey);

--- a/server/src/main/java/backend/section6mainproject/coordinate/interceptor/ConnectionInterceptor.java
+++ b/server/src/main/java/backend/section6mainproject/coordinate/interceptor/ConnectionInterceptor.java
@@ -6,6 +6,7 @@ import backend.section6mainproject.member.entity.Member;
 import backend.section6mainproject.member.service.MemberService;
 import backend.section6mainproject.walklog.entity.WalkLog;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.security.core.Authentication;
@@ -19,12 +20,14 @@ import java.util.List;
 import java.util.Map;
 
 @Component
+@Slf4j
 public class ConnectionInterceptor implements HandshakeInterceptor {
 
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
         String uri = request.getURI().toString();
         attributes.put("uri", uri);
+        log.info("connect success!");
         return true;
     }
 

--- a/server/src/main/java/backend/section6mainproject/helper/image/AWSS3StorageService.java
+++ b/server/src/main/java/backend/section6mainproject/helper/image/AWSS3StorageService.java
@@ -21,24 +21,35 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 import javax.annotation.PostConstruct;
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.time.Duration;
-import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @Slf4j
 public class AWSS3StorageService implements StorageService {
+    private static final float MAX_DIMENSION = 256;
     @Value("${aws-s3.access-key}")
     private String accessKey;
     @Value("${aws-s3.secret-access-key}")
     private String secretKey;
+    private final String REGEX = ".*\\.([^\\.]*)";
+    private final List<String> IMAGE_TYPE = List.of("jpg", "jpeg", "png");
     private S3Client s3Client;
     private S3Presigner s3Presigner;
     private Region clientRegion = Region.AP_NORTHEAST_2;
     private String bucket = "mainproject-gutter-ball-lay";
+    private String thumbnailBucket = "mainproject-gutter-ball-lay-resized";
 
     @PostConstruct
     private void createS3Client() {
@@ -56,30 +67,45 @@ public class AWSS3StorageService implements StorageService {
     }
 
     @Override
-    public String store(MultipartFile image, String directory) {
-        if(image == null || image.getContentType() == null || !image.getContentType().startsWith("image")) return null;
+    public String store(MultipartFile image, String directory, boolean thumbnailOnly) {
+        String imageType = getImageType(image);
+        if (imageType == null) return null;
+
         UUID uuid = UUID.randomUUID();
         String uploadImageName = directory + "/" + uuid + "_" + image.getOriginalFilename();
         try {
-            InputStream inputStream = image.getInputStream();
-            String uploadedFileName = uploadToS3(inputStream, uploadImageName, image.getContentType(), image.getSize());
-            return uploadedFileName;
+            if (!thumbnailOnly) {
+                uploadToS3(image.getBytes(), uploadImageName, image.getContentType(), image.getSize(), this.bucket);
+            }
+            ByteArrayOutputStream outputStream = resizeImageFile(image.getInputStream(), imageType);
+            uploadToS3(outputStream.toByteArray(), uploadImageName, image.getContentType(), outputStream.size(), this.thumbnailBucket);
+
+            return uploadImageName;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private String uploadToS3(InputStream is, String key, String contentType, long contentLength) {
+    private String getImageType(MultipartFile image) {
+        if(image == null || image.getContentType() == null || !image.getContentType().startsWith("image")) return null;
+        Matcher matcher = Pattern.compile(REGEX).matcher(image.getOriginalFilename());
+        if(!matcher.matches()) return null;
+
+        String imageType = matcher.group(1);
+        if(!IMAGE_TYPE.contains(imageType)) return null;
+        return imageType;
+    }
+
+    private String uploadToS3(byte[] bytes, String key, String contentType, long contentLength, String bucket) {
         PutObjectRequest objectRequest = PutObjectRequest.builder()
-                .bucket(this.bucket)
+                .bucket(bucket)
                 .key(key)
                 .contentType(contentType)
                 .contentLength(contentLength)
                 .build();
         try {
-            this.s3Client.putObject(objectRequest, RequestBody.fromInputStream(is, contentLength));
-            log.info("{} upload complete", objectRequest.key());
-            is.close();
+            this.s3Client.putObject(objectRequest, RequestBody.fromBytes(bytes));
+            log.info("{} upload complete in bucket {}", objectRequest.key(), bucket);
             return objectRequest.key();
         } catch (AwsServiceException e) {
             log.error("# AWS S3 error", e);
@@ -89,6 +115,38 @@ public class AWSS3StorageService implements StorageService {
             log.error("# AWS S3 error", e);
         }
         return null;
+    }
+
+    private ByteArrayOutputStream resizeImageFile(InputStream inputStream, String imageType){
+        try {
+            BufferedImage image = ImageIO.read(inputStream);
+            inputStream.close();
+            int srcHeight = image.getHeight();
+            int srcWidth = image.getWidth();
+            // Infer scaling factor to avoid stretching image unnaturally
+            float scalingFactor = Math.min(
+                    MAX_DIMENSION / srcWidth, MAX_DIMENSION / srcHeight);
+            int width = (int) (scalingFactor * srcWidth);
+            int height = (int) (scalingFactor * srcHeight);
+
+            BufferedImage resizedImage = new BufferedImage(width, height,
+                    BufferedImage.TYPE_INT_RGB);
+            Graphics2D graphics = resizedImage.createGraphics();
+            // Fill with white before applying semi-transparent (alpha) images
+            graphics.setPaint(Color.white);
+            graphics.fillRect(0, 0, width, height);
+            // Simple bilinear resize
+            graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                    RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            graphics.drawImage(image, 0, 0, width, height, null);
+            graphics.dispose();
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            ImageIO.write(resizedImage, imageType, outputStream);
+            return outputStream;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/server/src/main/java/backend/section6mainproject/helper/image/AWSS3StorageService.java
+++ b/server/src/main/java/backend/section6mainproject/helper/image/AWSS3StorageService.java
@@ -170,11 +170,20 @@ public class AWSS3StorageService implements StorageService {
 
 
     @Override
-    public String signBucket(String key) {
+    public String getPreSignedUrl(String key) {
+        return getPreSignedUrlInternal(key, this.bucket);
+    }
+
+    @Override
+    public String getPreSignedUrlForThumbnail(String key) {
+        return getPreSignedUrlInternal(key, this.thumbnailBucket);
+    }
+
+    private String getPreSignedUrlInternal(String key, String bucket) {
         if(key != null){
             try {
                 GetObjectRequest request = GetObjectRequest.builder()
-                        .bucket(this.bucket)
+                        .bucket(bucket)
                         .key(key)
                         .build();
                 GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()

--- a/server/src/main/java/backend/section6mainproject/helper/image/StorageService.java
+++ b/server/src/main/java/backend/section6mainproject/helper/image/StorageService.java
@@ -12,7 +12,7 @@ public interface StorageService {
      * @param directory 디렉토리명
      * @return imageKey - 디렉토리명과 파일명이 합쳐져 있습니다. 이미지 파일이 아닌 값이 들어가면 null을 반환합니다.
      */
-    String store(MultipartFile image, String directory);
+    String store(MultipartFile image, String directory, boolean thumbnailOnly);
 
     /**
      * 이미지 파일을 삭제하는 메서드

--- a/server/src/main/java/backend/section6mainproject/helper/image/StorageService.java
+++ b/server/src/main/java/backend/section6mainproject/helper/image/StorageService.java
@@ -10,6 +10,7 @@ public interface StorageService {
      *
      * @param image  이미지 파일
      * @param directory 디렉토리명
+     * @param thumbnailOnly true이면 썸네일만 저장하고 false이면 썸네일과 원본 모두 저장
      * @return imageKey - 디렉토리명과 파일명이 합쳐져 있습니다. 이미지 파일이 아닌 값이 들어가면 null을 반환합니다.
      */
     String store(MultipartFile image, String directory, boolean thumbnailOnly);
@@ -27,8 +28,11 @@ public interface StorageService {
      * @param key imageKey - 디렉토리명과 파일명이 합쳐져 있습니다.
      * @return pre-signed url. imageKey가 null이면 null을 반환합니다.
      */
-    @Named("signBucket")
-    String signBucket(String key);
+    @Named("PreSignedUrl")
+    String getPreSignedUrl(String key);
+
+    @Named("PreSignedUrlForThumbnail")
+    String getPreSignedUrlForThumbnail(String key);
 
     boolean isEmptyFile(MultipartFile image);
 

--- a/server/src/main/java/backend/section6mainproject/member/mapper/MemberMapper.java
+++ b/server/src/main/java/backend/section6mainproject/member/mapper/MemberMapper.java
@@ -19,7 +19,7 @@ public interface MemberMapper {
     @Mapping(target = "profileImage", ignore = true)
     Member updateInputToMember(MemberServiceDTO.UpdateInput updateInput); //서비스용DTO를 엔티티로 바꾼다. 서비스 계층에서만 사용됨
     MemberServiceDTO.FindNewPwInput getNewPwToFindNewPw(MemberControllerDTO.GetNewPw getNewPw);
-    @Mapping(source = "profileImage", target = "imageUrl", qualifiedByName = "signBucket")
+    @Mapping(source = "profileImage", target = "imageUrl", qualifiedByName = "PreSignedUrlForThumbnail")
     @Mapping(target = "totalWalkLog", source = "memberId", qualifiedByName = "countWalkLog")
     @Mapping(target = "totalWalkLogContent", source = "memberId", qualifiedByName = "countWalkLogContent")
     MemberServiceDTO.Output memberToOutput(Member member); // 서비스 계층에서 API계층으로 넘길때 사용됨

--- a/server/src/main/java/backend/section6mainproject/member/service/MemberServiceImpl.java
+++ b/server/src/main/java/backend/section6mainproject/member/service/MemberServiceImpl.java
@@ -103,7 +103,7 @@ public class MemberServiceImpl implements MemberService{
         //이제 변환된 엔티티 member를 서비스 비즈니스 계층에서 사용해도 된다.
         Member findMember = findVerifiedMember(member.getMemberId());
         Member updatedMember = beanUtils.copyNonNullProperties(member, findMember);
-        String profile = storageService.store(updateInput.getProfileImage(), "profile");
+        String profile = storageService.store(updateInput.getProfileImage(), "profile", true);
         if(profile != null || storageService.isEmptyFile(updateInput.getProfileImage())) {
             storageService.delete(findMember.getProfileImage());
             updatedMember.setProfileImage(profile);

--- a/server/src/main/java/backend/section6mainproject/walklog/mapper/WalkLogMapper.java
+++ b/server/src/main/java/backend/section6mainproject/walklog/mapper/WalkLogMapper.java
@@ -36,29 +36,29 @@ public interface WalkLogMapper {
     //Entity To Service
     @Mapping(source = "member.memberId",target = "memberId")
     @Mapping(source = "member.nickname",target = "nickname")
-    @Mapping(source = "mapImage",target = "imageUrl", qualifiedByName = "signBucket")
+    @Mapping(source = "mapImage",target = "imageUrl", qualifiedByName = "PreSignedUrlForThumbnail")
     @Mapping(target = "coordinates",qualifiedByName = "coordinateEntityToServiceDTO")
     @Mapping(target = "walkLogContents",qualifiedByName = "walkLogContentEntityToServiceDTO")
     WalkLogServiceDTO.Output walkLogToWalkLogServiceOutputDTO(WalkLog walkLog);
-    @Mapping(target = "walkLogContents",qualifiedByName = "walkLogContentEntityToServiceDTO")
+    @Mapping(target = "walkLogContents",qualifiedByName = "walkLogContentEntityToServiceDTOForThumbnail")
     @Mapping(target = "startedAt", source = "createdAt")
-    @Mapping(source = "mapImage",target = "mapImage", qualifiedByName = "signBucket")
+    @Mapping(source = "mapImage",target = "mapImage", qualifiedByName = "PreSignedUrlForThumbnail")
     WalkLogServiceDTO.FindOutput walkLogToWalkLogServiceFindOutputDTO(WalkLog walkLog);
     WalkLogServiceDTO.CreateOutput walkLogToWalkLogServiceCreatedOutputDTO(WalkLog walkLog);
     WalkLogServiceDTO.CalenderFindOutput walkLogToWalkLogServiceCalenderFindOutputDTO(WalkLog walkLog);
 
     @Mapping(source = "member.memberId",target = "memberId")
     @Mapping(source = "member.nickname",target = "nickname")
-    @Mapping(source = "member.profileImage",target = "profileImage",qualifiedByName = "signBucket")
-    @Mapping(source = "mapImage",target = "imageUrl", qualifiedByName = "signBucket")
+    @Mapping(source = "member.profileImage",target = "profileImage",qualifiedByName = "PreSignedUrlForThumbnail")
+    @Mapping(source = "mapImage",target = "imageUrl", qualifiedByName = "PreSignedUrlForThumbnail")
     @Mapping(target = "coordinates",qualifiedByName = "coordinateEntityToServiceDTO")
     @Mapping(target = "walkLogContents",qualifiedByName = "walkLogContentEntityToServiceDTO")
     WalkLogServiceDTO.GetOutput walkLogToWalkLogServiceGetOutPutDTO(WalkLog walkLog);
     @Mapping(source = "member.nickname",target = "nickname")
-    @Mapping(source = "member.profileImage",target = "profileImage",qualifiedByName = "signBucket")
-    @Mapping(target = "walkLogContents",qualifiedByName = "walkLogContentEntityToServiceDTO")
+    @Mapping(source = "member.profileImage",target = "profileImage",qualifiedByName = "PreSignedUrlForThumbnail")
+    @Mapping(target = "walkLogContents",qualifiedByName = "walkLogContentEntityToServiceDTOForThumbnail")
     @Mapping(target = "startedAt", source = "createdAt")
-    @Mapping(source = "mapImage",target = "mapImage",qualifiedByName = "signBucket")
+    @Mapping(source = "mapImage",target = "mapImage",qualifiedByName = "PreSignedUrlForThumbnail")
     WalkLogServiceDTO.FindFeedOutput walkLogToWalkLogServiceFindFeedOutputDTO(WalkLog walkLog);
 
     List<WalkLogServiceDTO.CalenderFindOutput> walkLogsToWalkLogServiceCalenderFindOutputDTOs(List<WalkLog> walkLogs);

--- a/server/src/main/java/backend/section6mainproject/walklog/service/WalkLogServiceImpl.java
+++ b/server/src/main/java/backend/section6mainproject/walklog/service/WalkLogServiceImpl.java
@@ -71,7 +71,7 @@ public class WalkLogServiceImpl implements WalkLogService {
     public WalkLogServiceDTO.Output exitWalkLog(WalkLogServiceDTO.ExitInput exitInput){
         WalkLog findWalkLog = findVerifiedWalkLog(exitInput.getWalkLogId());
         checkWalkLogStatusRecording(findWalkLog);
-        String mapImage = storageService.store(exitInput.getMapImage(), "mapImage");
+        String mapImage = storageService.store(exitInput.getMapImage(), "mapImage", false);
         WalkLog walkLog = walkLogMapper.walkLogServiceExitInputDTOtoWalkLog(exitInput);
         WalkLog exitedWalkLog =
                 beanUtils.copyNonNullProperties(walkLog, findWalkLog);

--- a/server/src/main/java/backend/section6mainproject/walklog/service/WalkLogServiceImpl.java
+++ b/server/src/main/java/backend/section6mainproject/walklog/service/WalkLogServiceImpl.java
@@ -71,7 +71,7 @@ public class WalkLogServiceImpl implements WalkLogService {
     public WalkLogServiceDTO.Output exitWalkLog(WalkLogServiceDTO.ExitInput exitInput){
         WalkLog findWalkLog = findVerifiedWalkLog(exitInput.getWalkLogId());
         checkWalkLogStatusRecording(findWalkLog);
-        String mapImage = storageService.store(exitInput.getMapImage(), "mapImage", false);
+        String mapImage = storageService.store(exitInput.getMapImage(), "mapImage", true);
         WalkLog walkLog = walkLogMapper.walkLogServiceExitInputDTOtoWalkLog(exitInput);
         WalkLog exitedWalkLog =
                 beanUtils.copyNonNullProperties(walkLog, findWalkLog);

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
     show-sql: true
   servlet:
     multipart:
-      max-file-size: 4MB
+      max-file-size: 5MB
 server:
   servlet:
     encoding:

--- a/server/src/main/resources/application-server.yml
+++ b/server/src/main/resources/application-server.yml
@@ -13,7 +13,7 @@ spring:
         format_sql: true  # (3) SQL pretty print
   servlet:
     multipart:
-      max-file-size: 4MB
+      max-file-size: 5MB
 server:
   servlet:
     encoding:

--- a/server/src/test/java/backend/section6mainproject/content/service/WalkLogContentServiceTest.java
+++ b/server/src/test/java/backend/section6mainproject/content/service/WalkLogContentServiceTest.java
@@ -54,7 +54,7 @@ class WalkLogContentServiceTest {
 
         given(mapper.serviceCreateInputDTOToEntity(Mockito.any(WalkLogContentServiceDTO.CreateInput.class))).willReturn(stubData.getWalkLogContent());
         given(walkLogService.findVerifiedWalkLog(Mockito.anyLong())).willReturn(new WalkLog());
-        given(storageService.store(Mockito.any(MultipartFile.class), Mockito.anyString())).willReturn("");
+        given(storageService.store(Mockito.any(MultipartFile.class), Mockito.anyString(), Mockito.anyBoolean())).willReturn("");
         given(walkLogContentRepository.save(Mockito.any(WalkLogContent.class))).willReturn(new WalkLogContent());
         given(mapper.entityToServiceCreateOutputDTO(Mockito.any(WalkLogContent.class))).willReturn(createOutput);
 
@@ -83,7 +83,7 @@ class WalkLogContentServiceTest {
         WalkLogContentServiceDTO.Output output = stubData.getOutput();
 
         given(walkLogContentRepository.findById(Mockito.anyLong())).willReturn(Optional.of(stubData.getWalkLogContent()));
-        given(storageService.store(Mockito.any(MultipartFile.class), Mockito.anyString())).willReturn("");
+        given(storageService.store(Mockito.any(MultipartFile.class), Mockito.anyString(), Mockito.anyBoolean())).willReturn("");
         given(walkLogContentRepository.save(Mockito.any(WalkLogContent.class))).willReturn(new WalkLogContent());
         given(mapper.entityToServiceOutputDTO(Mockito.any(WalkLogContent.class))).willReturn(output);
 

--- a/server/src/test/java/backend/section6mainproject/member/service/MemberServiceTest.java
+++ b/server/src/test/java/backend/section6mainproject/member/service/MemberServiceTest.java
@@ -20,6 +20,7 @@ import backend.section6mainproject.walklog.entity.WalkLog;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
@@ -92,10 +93,10 @@ public class MemberServiceTest {
         updateInput.setProfileImage(profileImage);
         Member member = stubData.getUpdatedMember();
 
-        when(memberRepository.findById(member.getMemberId())).thenReturn(Optional.of(member));
-        when(mapper.updateInputToMember(updateInput)).thenReturn(member);
-        when(storageService.store(updateInput.getProfileImage(), Mockito.anyString(), Mockito.anyBoolean())).thenReturn("newProfileImage");
-        when(beanUtils.copyNonNullProperties(member, member)).thenReturn(member);
+        when(memberRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(member));
+        when(mapper.updateInputToMember(Mockito.any(MemberServiceDTO.UpdateInput.class))).thenReturn(member);
+        when(storageService.store(Mockito.any(MultipartFile.class), Mockito.anyString(), Mockito.anyBoolean())).thenReturn("newProfileImage");
+        when(beanUtils.copyNonNullProperties(Mockito.any(Member.class), Mockito.any(Member.class))).thenReturn(member);
 
         // When
         MemberServiceDTO.Output output = memberService.updateMember(updateInput);

--- a/server/src/test/java/backend/section6mainproject/member/service/MemberServiceTest.java
+++ b/server/src/test/java/backend/section6mainproject/member/service/MemberServiceTest.java
@@ -94,7 +94,7 @@ public class MemberServiceTest {
 
         when(memberRepository.findById(member.getMemberId())).thenReturn(Optional.of(member));
         when(mapper.updateInputToMember(updateInput)).thenReturn(member);
-        when(storageService.store(updateInput.getProfileImage(), "profile")).thenReturn("newProfileImage");
+        when(storageService.store(updateInput.getProfileImage(), Mockito.anyString(), Mockito.anyBoolean())).thenReturn("newProfileImage");
         when(beanUtils.copyNonNullProperties(member, member)).thenReturn(member);
 
         // When

--- a/server/src/test/java/backend/section6mainproject/walklog/service/WalkLogServiceImplTest.java
+++ b/server/src/test/java/backend/section6mainproject/walklog/service/WalkLogServiceImplTest.java
@@ -171,7 +171,7 @@ public class WalkLogServiceImplTest {
 
         given(walkLogRepository.findById(Mockito.anyLong())).willReturn(Optional.of(walkLog));
         given(walkLogMapper.walkLogServiceExitInputDTOtoWalkLog(Mockito.any(WalkLogServiceDTO.ExitInput.class))).willReturn(walkLog);
-        given(storageService.store(Mockito.any(MultipartFile.class), Mockito.anyString())).willReturn("mapImage");
+        given(storageService.store(Mockito.any(MultipartFile.class), Mockito.anyString(), Mockito.anyBoolean())).willReturn("mapImage");
         given(beanUtils.copyNonNullProperties(Mockito.any(WalkLog.class),Mockito.any(WalkLog.class))).willReturn(new WalkLog());
         given(walkLogRepository.save(Mockito.any(WalkLog.class))).willReturn(new WalkLog());
         given(walkLogMapper.walkLogToWalkLogServiceOutputDTO(Mockito.any(WalkLog.class))).willReturn(output);


### PR DESCRIPTION
원본이미지와 썸네일용 이미지를 서로 다른 버킷에 저장합니다

원본 이미지는 순간기록 중 사진 한정으로 걷기 기록 조회(상세조회), 걷기 기록 수정, 걷기 기록 종료 시에만 응답하며
나머지 경우는 모두 썸네일을 응답합니다.

이미지 파일의 확장자는 jpg, jpeg, png만 허용됩니다.
이미지 파일 크기 제한 확대(4MB -> 5MB) 도 반영했습니다.