### PR TITLE
[FE] Refactor: axios interceptors로 토큰리프레시 & localStorage로 엑세스토큰 관리 & authAtom 통합

### DIFF
--- a/client/src/apis/instance.ts
+++ b/client/src/apis/instance.ts
@@ -21,3 +21,31 @@ export const fileAxios = axios.create({
   withCredentials: true,
 })
 
+export const authInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_ENDPOINT,
+  timeout: 3000,
+  headers: {
+    Authorization: getAccessTokenFromLocalStorage(),
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+})
+
+authInstance.interceptors.response.use(
+  response => response,
+  async error => {
+    const {
+      config,
+      response: { status },
+    } = error
+
+    if (status === 401) {
+      const originalRequest = config
+      const refreshRes = await axiosInstance.get('/members/refresh')
+      if (refreshRes.status === 200) {
+        return axios(originalRequest)
+      }
+    }
+    return Promise.reject(error)
+  }
+)

--- a/client/src/apis/instance.ts
+++ b/client/src/apis/instance.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
 import { getAccessTokenFromLocalStorage } from '../utils/accessTokenHandler'
 
 export const axiosInstance = axios.create({
@@ -20,6 +20,20 @@ export const fileAxios = axios.create({
   },
   withCredentials: true,
 })
+
+axiosInstance.interceptors.response.use(
+  config => {
+    const accessToken = getAccessTokenFromLocalStorage()
+    // eslint-disable-next-line no-param-reassign
+    config.headers = {
+      Authorization: accessToken || '',
+    }
+    return config
+  },
+  error => {
+    return Promise.reject(error)
+  }
+)
 
 export const authInstance = axios.create({
   baseURL: import.meta.env.VITE_API_ENDPOINT,

--- a/client/src/apis/instance.ts
+++ b/client/src/apis/instance.ts
@@ -1,65 +1,92 @@
-import axios, { AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
+/* eslint-disable no-param-reassign */
+import axios from 'axios'
 import { getAccessTokenFromLocalStorage } from '../utils/accessTokenHandler'
 
-export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_ENDPOINT,
-  timeout: 3000,
-  headers: {
-    Authorization: getAccessTokenFromLocalStorage(),
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-})
+const axiosInstance = createAxiosInstance()
+const fileAxios = createFileAxiosInstance()
+const authInstance = createAuthAxiosInstance()
 
-export const fileAxios = axios.create({
-  baseURL: import.meta.env.VITE_API_ENDPOINT,
-  timeout: 3000,
-  headers: {
-    Authorization: getAccessTokenFromLocalStorage(),
-    'Content-Type': 'multipart/form-data',
-  },
-  withCredentials: true,
-})
+function createAxiosInstance() {
+  const instance = axios.create({
+    baseURL: import.meta.env.VITE_API_ENDPOINT,
+    timeout: 3000,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    withCredentials: true,
+  })
 
-axiosInstance.interceptors.response.use(
-  config => {
+  instance.interceptors.request.use(config => {
     const accessToken = getAccessTokenFromLocalStorage()
-    // eslint-disable-next-line no-param-reassign
-    config.headers = {
-      Authorization: accessToken || '',
-    }
+    console.log('그냥인스턴스')
+    config.headers.Authorization = accessToken || ''
     return config
-  },
-  error => {
-    return Promise.reject(error)
-  }
-)
+  })
 
-export const authInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_ENDPOINT,
-  timeout: 3000,
-  headers: {
-    Authorization: getAccessTokenFromLocalStorage(),
-    'Content-Type': 'application/json',
-  },
-  withCredentials: true,
-})
+  return instance
+}
 
-authInstance.interceptors.response.use(
-  response => response,
-  async error => {
-    const {
-      config,
-      response: { status },
-    } = error
+function createFileAxiosInstance() {
+  const instance = axios.create({
+    baseURL: import.meta.env.VITE_API_ENDPOINT,
+    timeout: 3000,
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+    withCredentials: true,
+  })
 
-    if (status === 401) {
-      const originalRequest = config
-      const refreshRes = await axiosInstance.get('/members/refresh')
-      if (refreshRes.status === 200) {
-        return axios(originalRequest)
+  instance.interceptors.request.use(config => {
+    const accessToken = getAccessTokenFromLocalStorage()
+    config.headers.Authorization = accessToken || ''
+    return config
+  })
+
+  return instance
+}
+
+function createAuthAxiosInstance() {
+  const instance = axios.create({
+    baseURL: import.meta.env.VITE_API_ENDPOINT,
+    timeout: 3000,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    withCredentials: true,
+  })
+
+  instance.interceptors.request.use(config => {
+    const accessToken = getAccessTokenFromLocalStorage()
+    console.log('어쓰인스턴스')
+    config.headers.Authorization = accessToken || ''
+    return config
+  })
+
+  instance.interceptors.response.use(
+    response => response,
+    async error => {
+      const {
+        config,
+        response: { status },
+      } = error
+
+      if (status === 401) {
+        const originalRequest = config
+        try {
+          const refreshRes = await axiosInstance.get('/members/refresh')
+          if (refreshRes.status === 200) {
+            return await axios(originalRequest)
+          }
+        } catch (error) {
+          // Handle refresh token failure
+        }
       }
+
+      return Promise.reject(error)
     }
-    return Promise.reject(error)
-  }
-)
+  )
+
+  return instance
+}
+
+export { axiosInstance, fileAxios, authInstance }

--- a/client/src/apis/instance.ts
+++ b/client/src/apis/instance.ts
@@ -1,6 +1,9 @@
 /* eslint-disable no-param-reassign */
 import axios from 'axios'
-import { getAccessTokenFromLocalStorage } from '../utils/accessTokenHandler'
+import {
+  getAccessTokenFromLocalStorage,
+  saveAccessTokenToLocalStorage,
+} from '../utils/accessTokenHandler'
 
 const axiosInstance = createAxiosInstance()
 const fileAxios = createFileAxiosInstance()
@@ -57,7 +60,6 @@ function createAuthAxiosInstance() {
 
   instance.interceptors.request.use(config => {
     const accessToken = getAccessTokenFromLocalStorage()
-    console.log('어쓰인스턴스')
     config.headers.Authorization = accessToken || ''
     return config
   })
@@ -71,17 +73,17 @@ function createAuthAxiosInstance() {
       } = error
 
       if (status === 401) {
-        const originalRequest = config
         try {
           const refreshRes = await axiosInstance.get('/members/refresh')
           if (refreshRes.status === 200) {
-            return await axios(originalRequest)
+            saveAccessTokenToLocalStorage(refreshRes.headers.authorization)
+            config.headers.Authorization = refreshRes.headers.authorization
+            return await axios(config)
           }
         } catch (error) {
-          // Handle refresh token failure
+          console.log('refresh token error')
         }
       }
-
       return Promise.reject(error)
     }
   )

--- a/client/src/apis/instance.ts
+++ b/client/src/apis/instance.ts
@@ -1,11 +1,12 @@
 import axios from 'axios'
+import { getAccessTokenFromLocalStorage } from '../utils/accessTokenHandler'
 
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_ENDPOINT,
   timeout: 3000,
   headers: {
+    Authorization: getAccessTokenFromLocalStorage(),
     'Content-Type': 'application/json',
-    'ngrok-skip-browser-warning': '69420',
   },
   withCredentials: true,
 })
@@ -14,7 +15,9 @@ export const fileAxios = axios.create({
   baseURL: import.meta.env.VITE_API_ENDPOINT,
   timeout: 3000,
   headers: {
+    Authorization: getAccessTokenFromLocalStorage(),
     'Content-Type': 'multipart/form-data',
   },
   withCredentials: true,
 })
+

--- a/client/src/apis/instance.ts
+++ b/client/src/apis/instance.ts
@@ -56,7 +56,6 @@ function createAuthAxiosInstance() {
       return Promise.reject(error)
     }
   )
-
   return instance
 }
 

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,9 +1,10 @@
 import { AxiosError } from 'axios'
-import { axiosInstance, fileAxios } from './instance'
+import { authInstance, axiosInstance, fileAxios } from './instance'
 import {
   removeAccessTokenFromLocalStorage,
   saveAccessTokenToLocalStorage,
 } from '../utils/accessTokenHandler'
+import { UserInfoAtomType } from '../store/authAtom'
 
 type SignUpPropsType = {
   nickname: string
@@ -22,21 +23,14 @@ type SignInResType = {
   memberId: number | null
 }
 
-export type UserInfoType = {
-  defaultWalkLogPublicSetting: string
-  email: string
-  imageUrl: string
-  introduction: string
-  memberId: number
-  nickname: string
-  createdAt: string
-  totalWalkLog: number
-  totalWalkLogContent: number
+export const getCurrentUserInfo = async (): Promise<UserInfoAtomType | null> => {
+  try {
+    const response = await authInstance.get('/members/profile')
+    return response.data
+  } catch (error) {
+    return null
+  }
 }
-
-// GET 요청만 되고,
-// POST, PATCH, DELETE 요청은 403 forbidden (Invalid CORS Request)
-// 백엔드 서버에서 프론트 배포 서버만 허용해줬던 origin을 *(모두)로 변경
 
 export const signUp = async ({ nickname, email, password }: SignUpPropsType) => {
   try {
@@ -88,25 +82,6 @@ export const signIn = async ({
       }
     }
     return { status: 'unknown-error', memberId: null }
-  }
-}
-
-export const getUserInfo = async () => {
-  try {
-    const response = await axiosInstance.get('/members/profile')
-    return { status: 'success', userInfo: response.data }
-  } catch (error) {
-    console.error(error)
-    return { status: 'fail', userInfo: null }
-  }
-}
-
-export const getCurrentUserInfo = async (memberId: number): Promise<UserInfoType> => {
-  try {
-    const response = await axiosInstance.get(`/members/${memberId}`)
-    return response.data
-  } catch (error) {
-    throw new Error('Failed to fetch user info')
   }
 }
 

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -149,6 +149,7 @@ export const logoutUser = async () => {
 export const unregisterUser = async (memberId: number) => {
   try {
     await axiosInstance.delete(`/members/${memberId}`)
+    removeAccessTokenFromLocalStorage()
     return 'success'
   } catch (error) {
     console.log(error)

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,5 +1,9 @@
 import { AxiosError } from 'axios'
 import { axiosInstance, fileAxios } from './instance'
+import {
+  removeAccessTokenFromLocalStorage,
+  saveAccessTokenToLocalStorage,
+} from '../utils/accessTokenHandler'
 
 type SignUpPropsType = {
   nickname: string
@@ -67,8 +71,7 @@ export const signIn = async ({
   try {
     const response = await axiosInstance.post('/members/login', { email, password, autoLogin })
     const { authorization } = response.headers
-    axiosInstance.defaults.headers.common.Authorization = authorization
-    fileAxios.defaults.headers.common.Authorization = authorization
+    saveAccessTokenToLocalStorage(authorization)
     return { status: 'success', memberId: response.data.memberId }
   } catch (error: unknown) {
     const axiosError = error as AxiosError
@@ -171,8 +174,7 @@ export const getUserTempPassword = async (email: any) => {
 export const logoutUser = async () => {
   try {
     await axiosInstance.post(`/members/logout`)
-    delete axiosInstance.defaults.headers.common.Authorization
-    delete fileAxios.defaults.headers.common.Authorization
+    removeAccessTokenFromLocalStorage()
     return 'success'
   } catch (error) {
     console.log(error)

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -110,17 +110,6 @@ export const getCurrentUserInfo = async (memberId: number): Promise<UserInfoType
   }
 }
 
-export const refreshAccessToken = async () => {
-  try {
-    const { headers } = await axiosInstance.get('/members/refresh')
-    axiosInstance.defaults.headers.common.Authorization = headers.authorization
-    fileAxios.defaults.headers.common.Authorization = headers.authorization
-    return 'success'
-  } catch (error) {
-    return 'fail'
-  }
-}
-
 export const patchUserProfile = async (memberId: number, formData: FormData) => {
   try {
     const response = await fileAxios.patch(`/members/${memberId}`, formData)

--- a/client/src/components/ChangePassword/PasswordChanged.tsx
+++ b/client/src/components/ChangePassword/PasswordChanged.tsx
@@ -1,5 +1,5 @@
-import { useAtom } from 'jotai'
-import { isLoginAtom } from '../../store/authAtom'
+import { useSetAtom } from 'jotai'
+import { userInfoAtom } from '../../store/authAtom'
 import styles from './PasswordChanged.module.scss'
 import { logoutUser } from '../../apis/user'
 import useRouter from '../../hooks/useRouter'
@@ -13,11 +13,11 @@ export default function PasswordChanged({
   setIsChangingPassword,
   setIsPasswordChanged,
 }: PasswordChangedPropsType) {
-  const [, setIsLogin] = useAtom(isLoginAtom)
+  const setUserInfo = useSetAtom(userInfoAtom)
   const { routeTo } = useRouter()
   const handleLogout = async () => {
     await logoutUser()
-    setIsLogin(false)
+    setUserInfo(null)
     setIsChangingPassword(false)
     setIsPasswordChanged(false)
     routeTo('/signin')

--- a/client/src/components/HistoryDetail/DetailItem.tsx
+++ b/client/src/components/HistoryDetail/DetailItem.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import Icon from '../common/Icon'
 import styles from './DetailItem.module.scss'
 import ImgModal from './ImgModal'
 import { WalkLogContentsDataType, ModalOption } from '../../types/History'
 import { deleteHistoryItem } from '../../apis/history'
-import { isLoginAtom, idAtom } from '../../store/authAtom'
+import { userInfoAtom } from '../../store/authAtom'
 
 type DetailItemProps = {
   data: WalkLogContentsDataType
@@ -31,8 +31,7 @@ export default function DetailItem({
 }: DetailItemProps) {
   const { walkLogContentId, imageUrl, text } = data
   const [imgModal, setImgModal] = useState(false)
-  const [isLogin] = useAtom(isLoginAtom)
-  const [logInId] = useAtom(idAtom)
+  const userInfo = useAtomValue(userInfoAtom)
 
   const queryClient = useQueryClient()
 
@@ -77,7 +76,7 @@ export default function DetailItem({
           <div className={styles.icon}>
             <Icon name='time-gray' size={24} /> {snapTime}
           </div>
-          {isLogin && logInId === memberId && (
+          {userInfo && userInfo.memberId === memberId && (
             <div className={styles.editDeleteBox}>
               <button type='button' className={styles.icon} onClick={handleEditMode}>
                 <Icon name='edit-gray' size={24} />

--- a/client/src/components/HistoryDetail/Title.tsx
+++ b/client/src/components/HistoryDetail/Title.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import Icon from '../common/Icon'
 import styles from './Title.module.scss'
@@ -7,7 +7,7 @@ import { dateFormat, passedHourMinuteSecondFormat } from '../../utils/date'
 import { format } from '../../utils/date-fns'
 import DropDown from '../common/DropDown'
 import { patchHistory } from '../../apis/history'
-import { isLoginAtom, idAtom } from '../../store/authAtom'
+import { userInfoAtom } from '../../store/authAtom'
 
 type TitleProps = {
   id: string
@@ -32,8 +32,7 @@ export default function Title({
 }: TitleProps) {
   const [edit, setEdit] = useState(false)
   const [message, setMessage] = useState(text)
-  const [isLogin] = useAtom(isLoginAtom)
-  const [logInId] = useAtom(idAtom)
+  const userInfo = useAtomValue(userInfoAtom)
   const formattedTime = {
     date: dateFormat(new Date(startAt)),
     timer: passedHourMinuteSecondFormat(new Date(endAt).getTime() - new Date(startAt).getTime()),
@@ -100,7 +99,7 @@ export default function Title({
 
   return (
     <div className={styles.container}>
-      {logInId !== memberId && (
+      {userInfo?.memberId !== memberId && (
         <div className={styles.profileNicknameBox}>
           {profileImage ? (
             <img src={profileImage} alt='profile' />
@@ -110,7 +109,7 @@ export default function Title({
           <div>{nickname}</div>
         </div>
       )}
-      {isLogin && logInId === memberId && (
+      {userInfo?.memberId === memberId && (
         <DropDown currentSetting={setting} onSubmit={handlePublicSettingSubmit} />
       )}
       <div className={styles.timeBox}>
@@ -130,7 +129,7 @@ export default function Title({
       ) : (
         <div>
           <p className={styles.message}>{message}</p>
-          {isLogin && logInId === memberId && (
+          {userInfo?.memberId === memberId && (
             <div className={styles.editBtnBox}>
               <Icon name='edit-gray' />
               <button type='button' onClick={() => setEdit(prev => !prev)}>

--- a/client/src/components/HistoryList/Calendar/Calendar.tsx
+++ b/client/src/components/HistoryList/Calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import { useQuery } from '@tanstack/react-query'
 import {
   addMonths,
@@ -12,7 +12,7 @@ import styles from './Calendar.module.scss'
 import WeekDays from './WeekDays'
 import YearMonth from './YearMonth'
 import Dates from './Dates'
-import { userAtom } from '../../../store/authAtom'
+import { UserInfoAtomType, userInfoAtom } from '../../../store/authAtom'
 import { getHistoryCalendarList } from '../../../apis/history'
 import CalendarLoading from '../../../pages/loadingPage/CalendarLoading'
 
@@ -31,11 +31,11 @@ type CalendarProps = {
 }
 
 export default function Calendar({ date, setDate, selectDate, setSelectDate }: CalendarProps) {
-  const [user] = useAtom(userAtom)
+  const userInfo = useAtomValue(userInfoAtom) as UserInfoAtomType
 
   const getMonthHistoryQuery = useQuery({
     queryKey: ['history', date],
-    queryFn: () => getHistoryCalendarList(user.memberId, getYear(date), getMonth(date) + 1),
+    queryFn: () => getHistoryCalendarList(userInfo.memberId, getYear(date), getMonth(date) + 1),
     enabled: !!date,
   })
 

--- a/client/src/components/MyPage/EditProfile.tsx
+++ b/client/src/components/MyPage/EditProfile.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useAtom } from 'jotai'
 import styles from './EditProfile.module.scss'
 import ProfileImgInput from './ProfileImgInput'
-import { idAtom, userAtom } from '../../store/authAtom'
+import { userInfoAtom } from '../../store/authAtom'
 import { patchUserProfile } from '../../apis/user'
 
 type EditProfilePropsType = {
@@ -12,9 +12,8 @@ type EditProfilePropsType = {
 function EditProfile({ setIsModalOpened }: EditProfilePropsType) {
   const [imgFile, setImgFile] = useState<File | undefined>()
 
-  const [memberId] = useAtom(idAtom)
-  const [user, setUser] = useAtom(userAtom)
-  const [preview, setPreview] = useState<string>(user.imageUrl)
+  const [userInfo, setUserInfo] = useAtom(userInfoAtom)
+  const [preview, setPreview] = useState<string>(userInfo?.imageUrl || '')
 
   const handleCloseEditProfile = () => {
     setIsModalOpened(false)
@@ -28,7 +27,7 @@ function EditProfile({ setIsModalOpened }: EditProfilePropsType) {
     const image = formData.get('image')
     const data = new FormData()
 
-    if (nickname === user.nickname) {
+    if (nickname === userInfo?.nickname) {
       const blob = new Blob([JSON.stringify({ introduction })], {
         type: 'application/json',
       })
@@ -41,21 +40,19 @@ function EditProfile({ setIsModalOpened }: EditProfilePropsType) {
       data.append('patch', blob)
     }
 
-    // 기존 프로필 사진을 지우고 텍스트를 수정해서 보낸 경우
-    // image === null
     if (image instanceof File && !image.name && !preview) {
       data.append('profileImage', image)
     }
 
-    // 이미지를 수정한 경우
     if (image instanceof File && image.name && preview) {
       data.append('profileImage', image)
     }
 
-    if (memberId) {
-      const { status, resData } = await patchUserProfile(memberId, data)
+    if (userInfo?.memberId) {
+      console.log(userInfo.memberId)
+      const { status, resData } = await patchUserProfile(userInfo?.memberId, data)
       if (status === 'success' && resData) {
-        setUser(resData)
+        setUserInfo(resData)
         setIsModalOpened(false)
         return
       }
@@ -94,7 +91,7 @@ function EditProfile({ setIsModalOpened }: EditProfilePropsType) {
         <ProfileImgInput
           imgFile={imgFile}
           setImgFile={setImgFile}
-          profileImage={user.imageUrl ? user.imageUrl : ''}
+          profileImage={userInfo?.imageUrl ? userInfo.imageUrl : ''}
           preview={preview}
           setPreview={setPreview}
         />
@@ -105,7 +102,7 @@ function EditProfile({ setIsModalOpened }: EditProfilePropsType) {
           placeholder='이름'
           name='nickname'
           className={styles.editNameInput}
-          defaultValue={user.nickname}
+          defaultValue={userInfo?.nickname}
         />
       </div>
       <div className={styles.editIntroduction}>
@@ -113,7 +110,7 @@ function EditProfile({ setIsModalOpened }: EditProfilePropsType) {
           placeholder='자기소개'
           name='introduction'
           className={styles.editIntroductionInput}
-          defaultValue={user.introduction}
+          defaultValue={userInfo?.introduction || ''}
         />
       </div>
     </form>

--- a/client/src/components/header/HomeHeader.tsx
+++ b/client/src/components/header/HomeHeader.tsx
@@ -1,36 +1,29 @@
 import { Link } from 'react-router-dom'
 import Icon from '../common/Icon'
 import styles from './HomeHeader.module.scss'
+import { UserInfoAtomType } from '../../store/authAtom'
 
 type HomeHeaderProps = {
-  isLogin: boolean
-  userInfo: {
-    nickname: string
-    imageUrl: string
-    totalWalkLog: number
-    totalWalkLogContent: number
-  }
+  userInfo: UserInfoAtomType | null
 }
 
-export default function HomeHeader({ isLogin, userInfo }: HomeHeaderProps) {
-  const { nickname, imageUrl, totalWalkLog, totalWalkLogContent } = userInfo
-
+export default function HomeHeader({ userInfo }: HomeHeaderProps) {
   return (
     <div className={styles.headerContainer}>
       <div className={styles.profile}>
-        {isLogin && imageUrl ? (
-          <img src={imageUrl} alt={nickname} />
+        {userInfo && userInfo.imageUrl ? (
+          <img src={userInfo.imageUrl} alt={userInfo.nickname} />
         ) : (
           <Icon name='no-profile' size={48} />
         )}
       </div>
       <div className={styles.desc}>
-        {isLogin ? (
+        {userInfo ? (
           <>
-            <div className={styles.title}>{nickname}</div>
+            <div className={styles.title}>{userInfo.nickname}</div>
             <div className={styles.caption}>
-              <span>걷기 {totalWalkLog}</span>
-              <span>순간기록 {totalWalkLogContent}</span>
+              <span>걷기 {userInfo.totalWalkLog}</span>
+              <span>순간기록 {userInfo.totalWalkLogContent}</span>
             </div>
           </>
         ) : (
@@ -39,7 +32,6 @@ export default function HomeHeader({ isLogin, userInfo }: HomeHeaderProps) {
               <Link to='/signin'>로그인/회원가입</Link>
             </div>
             <div className={styles.caption}>걸은 순간을 기록으로 간직해보세요.</div>
-            {/* <div className={styles.caption}>로그인 없이 걷기를 체험할 수 있습니다.</div> */}
           </>
         )}
       </div>

--- a/client/src/components/header/OnWalkHeader.tsx
+++ b/client/src/components/header/OnWalkHeader.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai'
-import { isLoginAtom, userAtom } from '../../store/authAtom'
+import { userInfoAtom } from '../../store/authAtom'
 import { format } from '../../utils/date-fns'
 import Icon from '../common/Icon'
 import Timer from '../common/Timer'
@@ -11,16 +11,14 @@ interface OnWalkHeaderProps {
 }
 
 export default function OnWalkHeader({ startedAt, handleFinishClick }: OnWalkHeaderProps) {
-  const isLogin = useAtomValue(isLoginAtom)
-  const userInfo = useAtomValue(userAtom)
-
+  const userInfo = useAtomValue(userInfoAtom)
   const startedDate = new Date(startedAt)
 
   return (
     <div className={styles.container}>
       <div className={styles.infoBox}>
         <div className={styles.profileBox}>
-          {isLogin && userInfo.imageUrl ? (
+          {userInfo && userInfo.imageUrl ? (
             <img src={userInfo.imageUrl} alt={userInfo.nickname} />
           ) : (
             <Icon name='no-profile' size={48} />
@@ -32,7 +30,7 @@ export default function OnWalkHeader({ startedAt, handleFinishClick }: OnWalkHea
             <span className='time'>{format(startedDate, 'HH:mm:ss')}</span>
           </div>
           <p className={styles.text}>
-            {isLogin ? `${userInfo.totalWalkLog}번째 걷는 중이에요.` : '걷기 체험 중이에요.'}
+            {userInfo ? `${userInfo.totalWalkLog}번째 걷는 중이에요.` : '걷기 체험 중이에요.'}
           </p>
         </div>
       </div>

--- a/client/src/components/header/WalkHeader.tsx
+++ b/client/src/components/header/WalkHeader.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai'
-import { isLoginAtom, userAtom } from '../../store/authAtom'
+import { userInfoAtom } from '../../store/authAtom'
 import { format } from '../../utils/date-fns'
 import Icon from '../common/Icon'
 import Timer from '../common/Timer'
@@ -12,17 +12,18 @@ interface WalkHeaderProps {
 }
 
 export default function WalkHeader({ type, startedAt, handleFinishClick }: WalkHeaderProps) {
-  const isLogin = useAtomValue(isLoginAtom)
-  const userInfo = useAtomValue(userAtom)
+  const userInfo = useAtomValue(userInfoAtom)
 
   const startedDate = new Date(startedAt)
 
   const getMessage = (type: WalkHeaderProps['type']) => {
     if (type === 'ON') {
-      return `${userInfo.totalWalkLog}번째 걷는 중이에요.`
+      return userInfo ? `${userInfo.totalWalkLog}번째 걷는 중이에요.` : '걷기 체험 중이에요.'
     }
     if (type === 'AFTER') {
-      return `${userInfo.nickname}님의 ${userInfo.totalWalkLog}번째 걷기를 완료하셨어요.`
+      return userInfo
+        ? `${userInfo.nickname}님의 ${userInfo.totalWalkLog}번째 걷기를 완료하셨어요.`
+        : '걷기를 완료하셨어요.'
     }
   }
 
@@ -30,7 +31,7 @@ export default function WalkHeader({ type, startedAt, handleFinishClick }: WalkH
     <div className={styles.container}>
       <div className={styles.infoBox}>
         <div className={styles.profileBox}>
-          {isLogin && userInfo.imageUrl ? (
+          {userInfo && userInfo.imageUrl ? (
             <img src={userInfo.imageUrl} alt={userInfo.nickname} />
           ) : (
             <Icon name='no-profile' size={48} />

--- a/client/src/layout/GeneralLayout.tsx
+++ b/client/src/layout/GeneralLayout.tsx
@@ -1,11 +1,11 @@
-// import { useState, useEffect } from 'react'
-// import { useAtom } from 'jotai'
-import Tapbar from '../components/common/Tapbar'
-// import { userInfoAtom } from '../store/authAtom'
+import { useState, useEffect } from 'react'
+import { useSetAtom } from 'jotai'
 // import useRouter from '../hooks/useRouter'
-// import { getCurrentUserInfo } from '../apis/user'
+import { getCurrentUserInfo } from '../apis/user'
+import { userInfoAtom } from '../store/authAtom'
 import { TapBarContent } from '../router/routerData'
-// import Spinner from '../pages/loadingPage/Spinner'
+import Tapbar from '../components/common/Tapbar'
+import Spinner from '../pages/loadingPage/Spinner'
 
 type GeneralLayoutProps = {
   children: React.ReactNode
@@ -14,20 +14,22 @@ type GeneralLayoutProps = {
 }
 
 export default function GeneralLayout({ children, showTapBar, withAuth }: GeneralLayoutProps) {
-  // const [isAuthChecking, setIsAuthChecking] = useState(true)
-  // const [, setUserInfo] = useAtom(userInfoAtom)
-  // const [isLogin, setIsLogin] = useAtom(isLoginAtom)
-  // const [, setUser] = useAtom(userAtom)
-  // const [, setId] = useAtom(idAtom)
-  // const { routeTo, pathname } = useRouter()
-
-  // const authHandler = async () => {
-  //   const userInfo = await getCurrentUserInfo()
-  //   console.log('authHandler res', userInfo)
-  //   setUserInfo(userInfo)
-  // }
   console.log('withAuth', withAuth)
 
+  const [isAuthChecking, setIsAuthChecking] = useState(true)
+  const setUserInfo = useSetAtom(userInfoAtom)
+  // const { routeTo, pathname } = useRouter()
+
+  const authHandler = async () => {
+    const userInfo = await getCurrentUserInfo()
+    setUserInfo(userInfo)
+    setIsAuthChecking(false)
+  }
+
+  useEffect(() => {
+    console.log('app useEffect 실행')
+    authHandler()
+  }, [])
   // useEffect(() => {
   // console.log('app useEffect 실행')
   // authHandler().then(() => {
@@ -63,7 +65,7 @@ export default function GeneralLayout({ children, showTapBar, withAuth }: Genera
   // })
   // }, [])
 
-  // if (isAuthChecking) return <Spinner />
+  if (isAuthChecking) return <Spinner />
 
   return (
     <>

--- a/client/src/layout/GeneralLayout.tsx
+++ b/client/src/layout/GeneralLayout.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react'
-import { useAtom } from 'jotai'
+// import { useState, useEffect } from 'react'
+// import { useAtom } from 'jotai'
 import Tapbar from '../components/common/Tapbar'
-import { userInfoAtom } from '../store/authAtom'
+// import { userInfoAtom } from '../store/authAtom'
 // import useRouter from '../hooks/useRouter'
-import { getCurrentUserInfo } from '../apis/user'
+// import { getCurrentUserInfo } from '../apis/user'
 import { TapBarContent } from '../router/routerData'
-import Spinner from '../pages/loadingPage/Spinner'
+// import Spinner from '../pages/loadingPage/Spinner'
 
 type GeneralLayoutProps = {
   children: React.ReactNode
@@ -14,56 +14,56 @@ type GeneralLayoutProps = {
 }
 
 export default function GeneralLayout({ children, showTapBar, withAuth }: GeneralLayoutProps) {
-  const [isAuthChecking, setIsAuthChecking] = useState(true)
-  const [, setUserInfo] = useAtom(userInfoAtom)
+  // const [isAuthChecking, setIsAuthChecking] = useState(true)
+  // const [, setUserInfo] = useAtom(userInfoAtom)
   // const [isLogin, setIsLogin] = useAtom(isLoginAtom)
   // const [, setUser] = useAtom(userAtom)
   // const [, setId] = useAtom(idAtom)
   // const { routeTo, pathname } = useRouter()
 
-  const authHandler = async () => {
-    const userInfo = await getCurrentUserInfo()
-    console.log('authHandler res', userInfo)
-    setUserInfo(userInfo)
-  }
+  // const authHandler = async () => {
+  //   const userInfo = await getCurrentUserInfo()
+  //   console.log('authHandler res', userInfo)
+  //   setUserInfo(userInfo)
+  // }
+  console.log('withAuth', withAuth)
 
-  useEffect(() => {
-    console.log('app useEffect 실행')
-    console.log('withAuth', withAuth)
-    authHandler().then(() => {
-      setIsAuthChecking(false)
-    })
-    // const authHandler = async () => {
-    //   const { userInfo } = await getUserInfo()
-    //   if (userInfo === null) {
-    //     const isRefreshed = await refreshAccessToken()
-    //     if (isRefreshed === 'success') {
-    //       const { userInfo } = await getUserInfo()
-    //       if (userInfo) {
-    //         setIsLogin(true)
-    //         setId(userInfo.memberId)
-    //         setUser(userInfo)
-    //         return 'login'
-    //       }
-    //     } else {
-    //       setIsLogin(false)
-    //       return 'logout'
-    //     }
-    //   } else {
-    //     setIsLogin(true)
-    //     setId(userInfo.memberId)
-    //     setUser(userInfo)
-    //     return 'login'
-    //   }
-    // }
-    // authHandler().then(loginStatus => {
-    //   setIsAuthChecking(false)
-    //   if (!isLogin && withAuth && loginStatus === 'logout') routeTo('/signin')
-    //   if (isLogin && (pathname === '/signin' || pathname === '/signup')) routeTo('/')
-    // })
-  }, [])
+  // useEffect(() => {
+  // console.log('app useEffect 실행')
+  // authHandler().then(() => {
+  //   setIsAuthChecking(false)
+  // })
+  // const authHandler = async () => {
+  //   const { userInfo } = await getUserInfo()
+  //   if (userInfo === null) {
+  //     const isRefreshed = await refreshAccessToken()
+  //     if (isRefreshed === 'success') {
+  //       const { userInfo } = await getUserInfo()
+  //       if (userInfo) {
+  //         setIsLogin(true)
+  //         setId(userInfo.memberId)
+  //         setUser(userInfo)
+  //         return 'login'
+  //       }
+  //     } else {
+  //       setIsLogin(false)
+  //       return 'logout'
+  //     }
+  //   } else {
+  //     setIsLogin(true)
+  //     setId(userInfo.memberId)
+  //     setUser(userInfo)
+  //     return 'login'
+  //   }
+  // }
+  // authHandler().then(loginStatus => {
+  //   setIsAuthChecking(false)
+  //   if (!isLogin && withAuth && loginStatus === 'logout') routeTo('/signin')
+  //   if (isLogin && (pathname === '/signin' || pathname === '/signup')) routeTo('/')
+  // })
+  // }, [])
 
-  if (isAuthChecking) return <Spinner />
+  // if (isAuthChecking) return <Spinner />
 
   return (
     <>

--- a/client/src/layout/GeneralLayout.tsx
+++ b/client/src/layout/GeneralLayout.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react'
 import { useAtom } from 'jotai'
 import Tapbar from '../components/common/Tapbar'
-import { idAtom, isLoginAtom, userAtom } from '../store/authAtom'
-import useRouter from '../hooks/useRouter'
-import { getUserInfo, refreshAccessToken } from '../apis/user'
+import { userInfoAtom } from '../store/authAtom'
+// import useRouter from '../hooks/useRouter'
+import { getCurrentUserInfo } from '../apis/user'
 import { TapBarContent } from '../router/routerData'
 import Spinner from '../pages/loadingPage/Spinner'
 
@@ -15,45 +15,59 @@ type GeneralLayoutProps = {
 
 export default function GeneralLayout({ children, showTapBar, withAuth }: GeneralLayoutProps) {
   const [isAuthChecking, setIsAuthChecking] = useState(true)
-  const [isLogin, setIsLogin] = useAtom(isLoginAtom)
-  const [, setUser] = useAtom(userAtom)
-  const [, setId] = useAtom(idAtom)
-  const { routeTo, pathname } = useRouter()
+  const [, setUserInfo] = useAtom(userInfoAtom)
+  // const [isLogin, setIsLogin] = useAtom(isLoginAtom)
+  // const [, setUser] = useAtom(userAtom)
+  // const [, setId] = useAtom(idAtom)
+  // const { routeTo, pathname } = useRouter()
+
+  const authHandler = async () => {
+    const userInfo = await getCurrentUserInfo()
+    console.log('authHandler res', userInfo)
+    setUserInfo(userInfo)
+  }
 
   useEffect(() => {
-    const authHandler = async () => {
-      const { userInfo } = await getUserInfo()
-      if (userInfo === null) {
-        const isRefreshed = await refreshAccessToken()
-        if (isRefreshed === 'success') {
-          const { userInfo } = await getUserInfo()
-          if (userInfo) {
-            setIsLogin(true)
-            setId(userInfo.memberId)
-            setUser(userInfo)
-            return 'login'
-          }
-        } else {
-          setIsLogin(false)
-          return 'logout'
-        }
-      } else {
-        setIsLogin(true)
-        setId(userInfo.memberId)
-        setUser(userInfo)
-        return 'login'
-      }
-    }
-    authHandler().then(loginStatus => {
+    console.log('app useEffect 실행')
+    console.log('withAuth', withAuth)
+    authHandler().then(() => {
       setIsAuthChecking(false)
-      if (!isLogin && withAuth && loginStatus === 'logout') routeTo('/signin')
-      if (isLogin && (pathname === '/signin' || pathname === '/signup')) routeTo('/')
     })
-  }, [pathname, isLogin, withAuth])
+    // const authHandler = async () => {
+    //   const { userInfo } = await getUserInfo()
+    //   if (userInfo === null) {
+    //     const isRefreshed = await refreshAccessToken()
+    //     if (isRefreshed === 'success') {
+    //       const { userInfo } = await getUserInfo()
+    //       if (userInfo) {
+    //         setIsLogin(true)
+    //         setId(userInfo.memberId)
+    //         setUser(userInfo)
+    //         return 'login'
+    //       }
+    //     } else {
+    //       setIsLogin(false)
+    //       return 'logout'
+    //     }
+    //   } else {
+    //     setIsLogin(true)
+    //     setId(userInfo.memberId)
+    //     setUser(userInfo)
+    //     return 'login'
+    //   }
+    // }
+    // authHandler().then(loginStatus => {
+    //   setIsAuthChecking(false)
+    //   if (!isLogin && withAuth && loginStatus === 'logout') routeTo('/signin')
+    //   if (isLogin && (pathname === '/signin' || pathname === '/signup')) routeTo('/')
+    // })
+  }, [])
+
+  if (isAuthChecking) return <Spinner />
 
   return (
     <>
-      {isAuthChecking ? <Spinner /> : children}
+      {children}
       {showTapBar && <Tapbar tapBarContent={TapBarContent} />}
     </>
   )

--- a/client/src/layout/GeneralLayout.tsx
+++ b/client/src/layout/GeneralLayout.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useSetAtom } from 'jotai'
-// import useRouter from '../hooks/useRouter'
+import useRouter from '../hooks/useRouter'
 import { getCurrentUserInfo } from '../apis/user'
 import { userInfoAtom } from '../store/authAtom'
 import { TapBarContent } from '../router/routerData'
@@ -14,56 +14,27 @@ type GeneralLayoutProps = {
 }
 
 export default function GeneralLayout({ children, showTapBar, withAuth }: GeneralLayoutProps) {
-  console.log('withAuth', withAuth)
+  const { pathname, routeTo } = useRouter()
 
   const [isAuthChecking, setIsAuthChecking] = useState(true)
   const setUserInfo = useSetAtom(userInfoAtom)
-  // const { routeTo, pathname } = useRouter()
 
   const authHandler = async () => {
     const userInfo = await getCurrentUserInfo()
     setUserInfo(userInfo)
-    setIsAuthChecking(false)
+
+    if (!userInfo && withAuth) {
+      routeTo('/signin')
+    } else if (userInfo && (pathname === '/signin' || pathname === '/signup')) {
+      routeTo('/')
+    } else {
+      setIsAuthChecking(false)
+    }
   }
 
   useEffect(() => {
-    console.log('app useEffect 실행')
     authHandler()
-  }, [])
-  // useEffect(() => {
-  // console.log('app useEffect 실행')
-  // authHandler().then(() => {
-  //   setIsAuthChecking(false)
-  // })
-  // const authHandler = async () => {
-  //   const { userInfo } = await getUserInfo()
-  //   if (userInfo === null) {
-  //     const isRefreshed = await refreshAccessToken()
-  //     if (isRefreshed === 'success') {
-  //       const { userInfo } = await getUserInfo()
-  //       if (userInfo) {
-  //         setIsLogin(true)
-  //         setId(userInfo.memberId)
-  //         setUser(userInfo)
-  //         return 'login'
-  //       }
-  //     } else {
-  //       setIsLogin(false)
-  //       return 'logout'
-  //     }
-  //   } else {
-  //     setIsLogin(true)
-  //     setId(userInfo.memberId)
-  //     setUser(userInfo)
-  //     return 'login'
-  //   }
-  // }
-  // authHandler().then(loginStatus => {
-  //   setIsAuthChecking(false)
-  //   if (!isLogin && withAuth && loginStatus === 'logout') routeTo('/signin')
-  //   if (isLogin && (pathname === '/signin' || pathname === '/signup')) routeTo('/')
-  // })
-  // }, [])
+  }, [pathname])
 
   if (isAuthChecking) return <Spinner />
 

--- a/client/src/pages/AfterWalk.tsx
+++ b/client/src/pages/AfterWalk.tsx
@@ -10,7 +10,7 @@ import SnapItem from '../components/common/Item/SnapItem'
 import { differenceInSeconds } from '../utils/date-fns'
 import { deleteSnap, editSnap } from '../apis/snap'
 import DropDown from '../components/common/DropDown'
-import { userAtom } from '../store/authAtom'
+import { UserInfoAtomType, userInfoAtom } from '../store/authAtom'
 import { convertImageFromDataURL } from '../utils/imageConvertor'
 import StaticPathMap from '../components/common/Map/StaticPathMap'
 import useMapRef from '../hooks/useMapRef'
@@ -20,7 +20,7 @@ import AfterWalkLoading from './loadingPage/AfterWalkLoading'
 export default function AfterWalk() {
   const { routeTo } = useRouter()
   const { id: walkLogId } = useParams()
-  const userInfo = useAtomValue(userAtom)
+  const userInfo = useAtomValue(userInfoAtom) as UserInfoAtomType
 
   const [pubilcOption, setPublicOption] = useState<'PUBLIC' | 'PRIVATE'>(
     userInfo.defaultWalkLogPublicSetting

--- a/client/src/pages/ChangePassword.tsx
+++ b/client/src/pages/ChangePassword.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { useAtom } from 'jotai'
-import { userAtom, idAtom } from '../store/authAtom'
+import { useAtomValue } from 'jotai'
+import { UserInfoAtomType, userInfoAtom } from '../store/authAtom'
 import { signIn } from '../apis/user'
 import styles from './ChangePassword.module.scss'
 import ChangingPassword from '../components/ChangePassword/ChangingPassword'
@@ -12,14 +12,14 @@ export default function ChangePassword() {
   const [isPasswordChanged, setIsPasswordChanged] = useState(false)
   const [userId, setUserId] = useState(-1)
 
-  const [user] = useAtom(userAtom)
-  const [currentMemberId] = useAtom(idAtom)
-  const { email } = user
+  const userInfo = useAtomValue(userInfoAtom) as UserInfoAtomType
+  const currentMemberId = userInfo.memberId
 
   const confirmPassword = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const formData = new FormData(event.currentTarget)
     const password = formData.get('password')
+    const { email } = userInfo
     const { memberId } = await signIn({ email, password, autoLogin: true })
 
     if (memberId === currentMemberId) {

--- a/client/src/pages/HistoryDetail.tsx
+++ b/client/src/pages/HistoryDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import Title from '../components/HistoryDetail/Title'
 import styles from './HistoryDetail.module.scss'
 import { ko, format } from '../utils/date-fns'
@@ -10,7 +10,7 @@ import SnapForm from '../components/OnWalk/SnapForm'
 import Modal from '../components/common/Modal'
 import { deleteHistory, getHistory, patchHistoryItem } from '../apis/history'
 import { WalkLogContentsDataType, ModalOption } from '../types/History'
-import { isLoginAtom, idAtom } from '../store/authAtom'
+import { userInfoAtom } from '../store/authAtom'
 import Header from '../components/common/Header'
 import useRouter from '../hooks/useRouter'
 import HistoryDetailLoading from './loadingPage/HistoryDetailLoading'
@@ -26,8 +26,8 @@ export default function HistoryDetail() {
     title: '',
     deleteFn: () => {},
   })
-  const [isLogin] = useAtom(isLoginAtom)
-  const [logInId] = useAtom(idAtom)
+
+  const userInfo = useAtomValue(userInfoAtom)
 
   const mapRef = useMapRef()
 
@@ -38,11 +38,11 @@ export default function HistoryDetail() {
 
   const getHistoryQuery = useQuery({
     queryKey: ['history', id],
-    queryFn: () => getHistory(id!),
+    queryFn: () => getHistory(id as string),
   })
 
   const handleDeleteHistory = useMutation({
-    mutationFn: () => deleteHistory(id!),
+    mutationFn: () => deleteHistory(id as string),
     onSuccess: () => {
       queryClient.invalidateQueries(['history', id])
       routeTo('/history')
@@ -55,7 +55,7 @@ export default function HistoryDetail() {
     { contentId: string; formData: FormData },
     unknown
   >({
-    mutationFn: ({ contentId, formData }) => patchHistoryItem(id!, contentId, formData),
+    mutationFn: ({ contentId, formData }) => patchHistoryItem(id as string, contentId, formData),
     onSuccess: () => {
       queryClient.invalidateQueries(['history', id])
       setEdit(prev => !prev)
@@ -171,7 +171,7 @@ export default function HistoryDetail() {
           />
           <StaticPathMap ref={mapRef} path={dummypath} />
           {detailItems}
-          {isLogin && logInId === memberId && (
+          {userInfo?.memberId === memberId && (
             <div className={styles.deleteBtnBox}>
               <button type='button' className={styles.deleteBtn} onClick={handleHistoryDeleteModal}>
                 기록 삭제

--- a/client/src/pages/HistoryList.tsx
+++ b/client/src/pages/HistoryList.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useRef, useState } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import { Link } from 'react-router-dom'
 import styles from './HistoryList.module.scss'
 import History from '../components/HistoryList/History'
 import Calendar from '../components/HistoryList/Calendar/Calendar'
 import Toggle from '../components/HistoryList/Toggle'
 import { getHistoryList } from '../apis/history'
-import { isLoginAtom, userAtom } from '../store/authAtom'
+import { userInfoAtom, UserInfoAtomType } from '../store/authAtom'
 import { HistoryListDataType } from '../types/History'
 import { getDate, getMonth, getYear } from '../utils/date-fns'
 import HistoryLoading from './loadingPage/HistoryLoading'
@@ -17,8 +17,7 @@ export default function HistoryList() {
   const [calendar, setCalendar] = useState<boolean>(false)
   const [selectDate, setSelectDate] = useState<Date | null>(null)
   const [date, setDate] = useState<Date>(new Date())
-  const [user] = useAtom(userAtom)
-  const [isLogin] = useAtom(isLoginAtom)
+  const userInfo = useAtomValue(userInfoAtom) as UserInfoAtomType
 
   const handleCalendar = () => {
     setCalendar(!calendar)
@@ -29,7 +28,7 @@ export default function HistoryList() {
     queryFn: ({ pageParam }) => {
       if (calendar && selectDate) {
         return getHistoryList(
-          user.memberId,
+          userInfo.memberId,
           pageParam,
           getYear(selectDate),
           getMonth(selectDate) + 1,
@@ -37,9 +36,9 @@ export default function HistoryList() {
         )
       }
       if (calendar) {
-        return getHistoryList(user.memberId, pageParam, getYear(date), getMonth(date) + 1)
+        return getHistoryList(userInfo.memberId, pageParam, getYear(date), getMonth(date) + 1)
       }
-      return getHistoryList(user.memberId, pageParam)
+      return getHistoryList(userInfo.memberId, pageParam)
     },
     getNextPageParam: lastPage => {
       const { page, totalPages } = lastPage.pageInfo
@@ -92,7 +91,7 @@ export default function HistoryList() {
 
   return (
     <>
-      <HomeHeader isLogin={isLogin} userInfo={user} />
+      <HomeHeader userInfo={userInfo} />
       <div className={styles.container}>
         <Toggle handleCalendar={handleCalendar} calendar={calendar} />
         {calendar && (

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useAtomValue } from 'jotai'
-import { userAtom, isLoginAtom } from '../store/authAtom'
+import { userInfoAtom } from '../store/authAtom'
 import { startWalkLog } from '../apis/walkLog'
 import useMapRef from '../hooks/useMapRef'
 import useRouter from '../hooks/useRouter'
@@ -10,31 +10,15 @@ import { getDistanceBetweenPosition } from '../utils/position'
 import styles from './Home.module.scss'
 
 export default function Home() {
+  const userInfo = useAtomValue(userInfoAtom)
   const { routeTo } = useRouter()
+  const mapRef = useMapRef()
   const [position, setPosition] = useState<google.maps.LatLngLiteral | null>(null)
 
-  const isLogin = useAtomValue(isLoginAtom)
-  const user = useAtomValue(userAtom)
-
-  const mapRef = useMapRef()
-
-  const userInfo = {
-    nickname: user.nickname,
-    imageUrl: user.imageUrl,
-    totalWalkLog: user.totalWalkLog,
-    totalWalkLogContent: user.totalWalkLogContent,
-  }
-
   const handleStartClick = async () => {
-    if (!isLogin) {
-      console.log('비로그인 시작 x')
-      return
-    }
-    const { walkLogId } = await startWalkLog(user.memberId)
-    if (walkLogId === -1) {
-      console.log('시작 실패')
-      return
-    }
+    if (!userInfo) return
+    const { walkLogId } = await startWalkLog(userInfo.memberId)
+    if (walkLogId === -1) return
     routeTo(`/onwalk/${walkLogId}`)
   }
 
@@ -68,7 +52,7 @@ export default function Home() {
 
   return (
     <div className={styles.container}>
-      <HomeHeader isLogin={isLogin} userInfo={userInfo} />
+      <HomeHeader userInfo={userInfo} />
       {position ? (
         <LiveMap ref={mapRef} mapSize={MapSize.LARGE} path={[position]} />
       ) : (

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -1,16 +1,14 @@
 import { Link } from 'react-router-dom'
-import { useAtom } from 'jotai'
-import { signIn, getUserInfo } from '../apis/user'
+import { useSetAtom } from 'jotai'
+import { signIn, getCurrentUserInfo } from '../apis/user'
 import styles from './SignIn.module.scss'
-import { idAtom, isLoginAtom, userAtom } from '../store/authAtom'
+import { userInfoAtom } from '../store/authAtom'
 import useRouter from '../hooks/useRouter'
 import Header from '../components/common/Header'
 
 function SignIn() {
   const { routeTo } = useRouter()
-  const [, setUser] = useAtom(userAtom)
-  const [, setId] = useAtom(idAtom)
-  const [, setIsLogin] = useAtom(isLoginAtom)
+  const setUserInfo = useSetAtom(userInfoAtom)
 
   const logInSubmitHandler = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -20,14 +18,11 @@ function SignIn() {
     const email = formData.get('email')
     const password = formData.get('password')
 
-    const { status, memberId } = await signIn({ email, password, autoLogin: true })
+    const { status } = await signIn({ email, password, autoLogin: true })
 
-    if (memberId) {
-      setId(memberId)
-      const { userInfo } = await getUserInfo()
-      // 전역 상태에 userInfoRes 저장
-      setIsLogin(true)
-      setUser(userInfo)
+    if (status === 'success') {
+      const userInfo = await getCurrentUserInfo()
+      setUserInfo(userInfo)
       routeTo('/')
       return
     }

--- a/client/src/store/authAtom.ts
+++ b/client/src/store/authAtom.ts
@@ -29,3 +29,18 @@ export const idAtom = atom<number>(0)
 
 // 로그인 여부
 export const isLoginAtom = atom<boolean>(false)
+
+export type UserInfoAtomType = {
+  createdAt: string
+  email: string
+  memberId: number
+  nickname: string
+  introduction: string | null
+  imageUrl: string | null
+  totalWalkLog: number
+  totalWalkLogContent: number
+  recordingWalkLogId: number | null
+  defaultWalkLogPublicSetting: 'PRIVATE' | 'PUBLIC'
+}
+
+export const userInfoAtom = atom<UserInfoAtomType | null>(null)

--- a/client/src/store/authAtom.ts
+++ b/client/src/store/authAtom.ts
@@ -1,35 +1,5 @@
 import { atom } from 'jotai'
 
-type UserAtomType = {
-  defaultWalkLogPublicSetting: 'PRIVATE' | 'PUBLIC'
-  email: string
-  imageUrl: string
-  introduction: string
-  memberId: number
-  nickname: string
-  createdAt: string
-  totalWalkLog: number
-  totalWalkLogContent: number
-}
-// 유저 정보
-export const userAtom = atom<UserAtomType>({
-  defaultWalkLogPublicSetting: 'PRIVATE',
-  email: '',
-  imageUrl: '',
-  introduction: '',
-  memberId: 0,
-  nickname: '',
-  createdAt: '',
-  totalWalkLog: 0,
-  totalWalkLogContent: 0,
-})
-
-// member id
-export const idAtom = atom<number>(0)
-
-// 로그인 여부
-export const isLoginAtom = atom<boolean>(false)
-
 export type UserInfoAtomType = {
   createdAt: string
   email: string

--- a/client/src/utils/accessTokenHandler.ts
+++ b/client/src/utils/accessTokenHandler.ts
@@ -1,0 +1,33 @@
+const isBrowser = () => typeof window !== 'undefined'
+
+export const saveAccessTokenToLocalStorage = (accessToken: string) => {
+  if (isBrowser()) {
+    try {
+      localStorage.setItem('accessToken', accessToken)
+    } catch (error) {
+      console.error('Error saving accessToken to local storage:', error)
+    }
+  }
+}
+
+export const getAccessTokenFromLocalStorage = () => {
+  if (isBrowser()) {
+    try {
+      return localStorage.getItem('accessToken') || ''
+    } catch (error) {
+      console.error('Error getting accessToken from local storage:', error)
+      return ''
+    }
+  }
+  return ''
+}
+
+export const removeAccessTokenFromLocalStorage = () => {
+  if (isBrowser()) {
+    try {
+      localStorage.removeItem('accessToken')
+    } catch (error) {
+      console.error('Error removing accessToken from local storage:', error)
+    }
+  }
+}


### PR DESCRIPTION
1. ✅ axios interceptors로 리프레시토큰 요청 
    - 현재 GeneralLayout에 있는 리프레시토큰 요청 로직을 axios interceptors로 처리해서 로직을 api함수 내부로 옮김
    - 결과적으로 `getCurrentUserInfo` 안에서 전부 처리되게 변경

2. ✅ localStorage로 엑세스토큰 관리
    - 웹소켓 관련 로직에 엑세스토큰이 필요한데, 현재는 엑세스토큰을 따로 변수로 저장하지 않음
    - 엑세스토큰을 로컬스토리지에 저장해 웹소켓 로직에서 불러와 사용할 수 있도록 함
    - 엑세스토큰은 유효기간이 1시간이고, 리프레시토큰이 https only cookie로 저장되어 보안상 크게 문제가 없다고 판단
    - `utils/accessTokenHandler.ts` 로 관리

3. ✅authAtom 간소화 및 리펙토링
     - userAtom을 null vs object 로 구분해서 userAtom, idAtom, isLoginAtom의 역할을 전부 대체할 수 있도록 변경하고, 하나만 관리하면 되게 변경
         - userAtom, idAtom, isLoginAtom 의 사용방식이 정의되지 않음(같은 로직인데 a파일은 id, b파일은 islogin 사용)
         - idAtom, isLoginAtom은 userAtom에 동일한 정보가 있음
         - 로그아웃 처리 시, 기존에 로그인 됐던 유저정보가 userAtom에 살아있음(초기화되지 않음)
         - userAtom의 초기값이 실제 서버에서 받아오는 초기값과 차이가 있음 (null vs '')
