### PR TITLE
[FE] 마이페이지, 기록리스트페이지 접근 시 redirect하지않고 자체적으로 콘텐츠 보여주기

### DIFF
--- a/client/src/components/common/Header.module.scss
+++ b/client/src/components/common/Header.module.scss
@@ -6,35 +6,33 @@
   width: 100%;
   height: 48px;
   padding: 8px 20px;
-  @include U.flex-c(row, center, center);
+  @include U.flex-c(row, space-between, center);
   background-color: C.$white;
   border-bottom: 1px solid C.$gray200;
 }
 
 .backBtn {
   @include U.flex-c(row, flex-start, center);
-  width: 20%;
+  @include U.size(24px);
 }
 
 .noBackBtn {
   @include U.flex-c(row, flex-start, center);
-  width: 20%;
+  @include U.size(24px);
 }
 
 .headerTitle {
   @include U.flex-c(row, center, center);
   color: black;
-  font-size: 1.6rem;
-  width: 60%;
 }
 
 .closeBtn {
   @include U.flex-c(row, flex-end, center);
   @include T.gray900-regular-14;
-  width: 20%;
+  @include U.size(24px);
 }
 
 .noCloseBtn {
   @include U.flex-c(row, flex-end, center);
-  width: 20%;
+  @include U.size(24px);
 }

--- a/client/src/layout/GeneralLayout.tsx
+++ b/client/src/layout/GeneralLayout.tsx
@@ -22,10 +22,9 @@ export default function GeneralLayout({ children, showTapBar, withAuth }: Genera
   const authHandler = async () => {
     const userInfo = await getCurrentUserInfo()
     setUserInfo(userInfo)
+    console.log(withAuth)
 
-    if (!userInfo && withAuth) {
-      routeTo('/signin')
-    } else if (userInfo && (pathname === '/signin' || pathname === '/signup')) {
+    if (userInfo && (pathname === '/signin' || pathname === '/signup')) {
       routeTo('/')
     } else {
       setIsAuthChecking(false)

--- a/client/src/pages/HistoryList.tsx
+++ b/client/src/pages/HistoryList.tsx
@@ -7,7 +7,7 @@ import History from '../components/HistoryList/History'
 import Calendar from '../components/HistoryList/Calendar/Calendar'
 import Toggle from '../components/HistoryList/Toggle'
 import { getHistoryList } from '../apis/history'
-import { userInfoAtom, UserInfoAtomType } from '../store/authAtom'
+import { UserInfoAtomType, userInfoAtom } from '../store/authAtom'
 import { HistoryListDataType } from '../types/History'
 import { getDate, getMonth, getYear } from '../utils/date-fns'
 import HistoryLoading from './loadingPage/HistoryLoading'
@@ -19,9 +19,7 @@ export default function HistoryList() {
   const [date, setDate] = useState<Date>(new Date())
   const userInfo = useAtomValue(userInfoAtom) as UserInfoAtomType
 
-  const handleCalendar = () => {
-    setCalendar(!calendar)
-  }
+  const intObserver = useRef<IntersectionObserver>()
 
   const { isError, data, isFetchingNextPage, hasNextPage, fetchNextPage } = useInfiniteQuery({
     queryKey: ['history', calendar, date, selectDate],
@@ -46,7 +44,6 @@ export default function HistoryList() {
     },
   })
 
-  const intObserver = useRef<IntersectionObserver>()
   const lastHistoryRef = useCallback(
     (history: HTMLDivElement) => {
       if (isFetchingNextPage) return
@@ -64,6 +61,28 @@ export default function HistoryList() {
     },
     [isFetchingNextPage, fetchNextPage, hasNextPage]
   )
+
+  const handleCalendar = () => {
+    setCalendar(!calendar)
+  }
+
+  if (!userInfo) {
+    return (
+      <div className={styles.noHistoryBox}>
+        <p>
+          로그인/회원가입을 하고
+          <br />
+          오늘의 기록을 남겨보세요!
+        </p>
+        <Link to='/signin' className={styles.linkBtn}>
+          로그인 하러가기
+        </Link>
+        <Link to='/signup' className={styles.linkBtn}>
+          회원가입 하러가기
+        </Link>
+      </div>
+    )
+  }
 
   if (isError) return <h1>Fail...</h1>
 

--- a/client/src/pages/MyPage.module.scss
+++ b/client/src/pages/MyPage.module.scss
@@ -104,3 +104,26 @@
   color: C.$gray600;
   margin-top: 20px;
 }
+
+.noHistoryBox {
+  width: 100%;
+  text-align: center;
+  margin-top: 100px;
+  @include U.flex-c(column, center, center);
+  gap: 20px;
+  font-size: 18px;
+}
+
+.homeBtn {
+  border: 1px solid C.$gray900;
+  padding: 15px;
+  border-radius: 12px;
+}
+
+.linkBtn {
+  @include U.flex-c(row, center, center);
+  @include U.size(200px, 48px);
+  background: C.$gray200;
+  border-radius: 8px;
+  font-size: 16px;
+}

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -10,7 +10,6 @@ import { logoutUser, patchUserPrivacySettings, unregisterUser } from '../apis/us
 import Icon from '../components/common/Icon'
 import Modal from '../components/common/Modal'
 import useRouter from '../hooks/useRouter'
-import MyPageLoading from './loadingPage/MyPageLoading'
 
 type UnregisterModalOptionType = {
   title: string

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -10,6 +10,7 @@ import { logoutUser, patchUserPrivacySettings, unregisterUser } from '../apis/us
 import Icon from '../components/common/Icon'
 import Modal from '../components/common/Modal'
 import useRouter from '../hooks/useRouter'
+import MyPageLoading from './loadingPage/MyPageLoading'
 
 type UnregisterModalOptionType = {
   title: string
@@ -132,6 +133,22 @@ export default function Mypage() {
       setRegisteredAt(formattedData)
     }
   }, [userInfo])
+
+  if (!userInfo) {
+    return (
+      <div className={styles.noHistoryBox}>
+        <p>
+          <strong>내정보</strong>는 로그인 후 이용하실 수 있습니다.
+        </p>
+        <Link to='/signin' className={styles.linkBtn}>
+          로그인 하러가기
+        </Link>
+        <Link to='/signup' className={styles.linkBtn}>
+          회원가입 하러가기
+        </Link>
+      </div>
+    )
+  }
 
   return (
     <>

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -37,7 +37,7 @@ function SignIn() {
         hasCloseButton={false}
         headerTitle='로그인'
         handleCloseFn={() => {}}
-        path='/'
+        path='-1'
       />
       <form className={styles.formContainer} onSubmit={logInSubmitHandler}>
         <div className={styles.inputBox}>

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -116,7 +116,7 @@ function SignUp() {
           hasCloseButton
           headerTitle='이용약관'
           handleCloseFn={setIsTermOfUseOpened}
-          path='/signup'
+          path='-1'
         />
         <div className={styles.termContainer}>
           안고, 바이며, 있을 이 없으면 불어 인간의 할지니, 듣는다. 하였으며, 착목한는 얼마나 석가는
@@ -165,7 +165,7 @@ function SignUp() {
           hasCloseButton
           headerTitle='개인정보 처리방침'
           handleCloseFn={setIsPrivacyPolicyOpened}
-          path='/signup'
+          path='-1'
         />
         <div className={styles.termContainer}>
           안고, 바이며, 있을 이 없으면 불어 인간의 할지니, 듣는다. 하였으며, 착목한는 얼마나 석가는
@@ -214,7 +214,7 @@ function SignUp() {
         hasCloseButton={false}
         headerTitle='회원가입'
         handleCloseFn={() => {}}
-        path='/signin'
+        path='-1'
       />
       <form
         className={styles.formContainer}

--- a/client/src/pages/loadingPage/MyPageLoading.tsx
+++ b/client/src/pages/loadingPage/MyPageLoading.tsx
@@ -21,7 +21,7 @@ function ProfileBox() {
   )
 }
 
-export default function MypPageLoading() {
+export default function MyPageLoading() {
   return (
     <div className={styles.container}>
       <ProfileBox />

--- a/client/src/router/routerData.tsx
+++ b/client/src/router/routerData.tsx
@@ -5,7 +5,7 @@ import HistoryDetailLoading from '../pages/loadingPage/HistoryDetailLoading'
 import HistoryListLoading from '../pages/loadingPage/HistoryListLoading'
 import HomeLoading from '../pages/loadingPage/HomeLoading'
 import FeedLoading from '../pages/loadingPage/FeedLoading'
-import MypPageLoading from '../pages/loadingPage/MyPageLoading'
+import MyPageLoading from '../pages/loadingPage/MyPageLoading'
 import OnWalkLoading from '../pages/loadingPage/OnWalkLoading'
 import AfterWalkLoading from '../pages/loadingPage/AfterWalkLoading'
 
@@ -94,7 +94,7 @@ export const routerData: RouterElement[] = [
     path: '/mypage',
     label: '내정보',
     element: (
-      <Suspense fallback={<MypPageLoading />}>
+      <Suspense fallback={<MyPageLoading />}>
         <MyPage />
       </Suspense>
     ),


### PR DESCRIPTION
마이페이지, 기록리스트페이지 접근 시 redirect하지않고 자체적으로 콘텐츠 보여주기
백엔드와 협의해서 페이지마다 path별로 다른 api요청을 보내게 변경할 예정이라서, redirect를 변경해줘야 함



 - [x] 비로그인 마이페이지 접근 시 => 로그인, 회원가입 버튼 제공
 - [x] 비로그인 기록리스트 접근 시 => 로그인, 회원가입 버튼 제공
 - [x] 헤더 뒤로가기 버튼 path 설정하기